### PR TITLE
Updates the Linux DNS configuration

### DIFF
--- a/roles/linux-common/tasks/main.yml
+++ b/roles/linux-common/tasks/main.yml
@@ -6,32 +6,22 @@
   with_items:
     - NetworkManager
 
-- command: find /etc/sysconfig/network-scripts/ -type f -name "ifcfg-e*"
-  register: eths
+- name: create dhclient.conf
+  file:
+    path: /etc/dhcp/dhclient.conf
+    state: touch
+    owner: root
+    group: root
+    mode: '0644'
 
-- name: Remove PeerDNS=yes entry
-  lineinfile:
-    path: "{{ item }}"
-    regexp: '^PEERDNS=yes'
-    line: ''
-  with_items: "{{ eths.stdout_lines }}"
-
-- name: set DNS resolution in ifcfg file
+- name: set custom DNS server
   blockinfile:
-    dest: "{{ item }}"
+    dest: /etc/dhcp/dhclient.conf
     block: |
-      DNS1={{ dns_server }}
-      DOMAIN="{{ dns_domain_name }} ec2.internal"
-      PEERDNS=no
+      prepend domain-name-servers {{ hostvars['windc']['private_ip'] }};
+      prepend domain-search "{{ dns_domain_name }}", "ec2.internal";
+    state: present
   register: dnschange
-  with_items: "{{ eths.stdout_lines }}"
-
-- name: set DNS resolution in resolv.conf file
-  template:
-    src: templates/resolv.conf.j2
-    dest: /etc/resolv.conf
-
-  register: etchost
 
 - name: restart NetworkManager
   service:


### PR DESCRIPTION
The current role configures the NIC on Linux boxes so that they use a set of custom DNS (that matches the IP of the AD domain) and the custom search domain by injecting a block in `/etc/sysconfig/network-scripts/ifcfg-eth0`.
However, this change doesn't work when Amazon custom DNS is injected via DHCP. 
As a result, Amazon DNS server and search domain take precedence over the custom DNS configuration, which breaks the DNS configuration when the instance is restarted.

This pull request makes use of the "prepend" DHCP option to instruct the DHCP to inject custom information before considering Amazon EC2 DHCP information. This includes the DNS search domain and the IP address of the AD server. 
The resulting `/etc/resolv.conf` will *always* look like this without touching `/etc/sysconfig/network-scripts/ifcfg-eth0`

```
# Generated by NetworkManager
search $SEARCH_DOMAIN ec2.internal
nameserver $AD_SERVER
nameserver $AMAZON_DNS
```
For more information on EC2 and DNS, see [this link](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-static-dns-ubuntu-debian/) (AWS premium support knowledgebase)