### PR TITLE
fix kerberos auth and switch to credssp as default in the inventory

### DIFF
--- a/roles/ansible-tower/tasks/main.yml
+++ b/roles/ansible-tower/tasks/main.yml
@@ -75,7 +75,7 @@
     dest: /etc/krb5.conf
     owner: root
     group: root
-    mode: 0600
+    mode: 0644
 
 #- name: Install dependencies for domain join
 #  package:

--- a/roles/ansible-tower/templates/tower_host.json.j2
+++ b/roles/ansible-tower/templates/tower_host.json.j2
@@ -4,5 +4,5 @@
     "inventory": 2,
     "enabled": true,
     "instance_id": "",
-    "variables": "ansible_port: 5986\nansible_connection: winrm\nansible_winrm_server_cert_validation: ignore\nansible_winrm_transport: ntlm"
+    "variables": "ansible_port: 5986\nansible_connection: winrm\nansible_winrm_server_cert_validation: ignore\nansible_winrm_transport: credssp"
 }


### PR DESCRIPTION
…due to the fact that krb5.conf file is not readable by the awx user. This commit fixes that

- switch student tower inventory host to use credssp as that's working as expected. We can even consider using kerberos. NTLM should be avoided as it won't support some scenarios that might be needed in the future.