### PR TITLE
Rhel8 support

### DIFF
--- a/roles/ansible-tower/tasks/main.yml
+++ b/roles/ansible-tower/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - name: Enable extras repos
   shell: yum-config-manager --enable rhui-REGION-rhel-server-extras
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version|int < 8
+    - instance_loc == 'ec2'
 
 - name: Add Ansible repo - transition to engine...
   yum_repository:
@@ -9,6 +13,16 @@
     baseurl: http://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/
     enabled: yes
     gpgcheck: no
+  when: ansible_distribution_major_version|int < 8
+
+- name: Add Epel repo
+  yum_repository:
+    name: epel
+    description: EPEL for Enterprise Linux 8
+    baseurl: https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/
+    enabled: yes
+    gpgcheck: no
+  when: ansible_distribution_major_version|int == 8
 
 - name: Install packages
   package:
@@ -21,6 +35,20 @@
       - bind-utils
       - python-pip
     state: present
+  when: ansible_distribution_major_version|int < 8
+
+- name: Install packages
+  package:
+    name:
+      - vim
+      - git
+#      - sshpass
+#      - ansible
+      - nano
+      - bind-utils
+      - python36
+    state: present
+  when: ansible_distribution_major_version|int == 8
 
 #- name: Install devel branch
 #  pip:
@@ -56,6 +84,17 @@
       - python-kerberos
       - gcc
     state: present
+  when: ansible_distribution_major_version|int < 8
+
+- name: Install dependencies for Kerberos auth
+  package:
+    name:
+      - krb5-devel
+      - krb5-libs
+      - krb5-workstation
+      - gcc
+    state: present
+  when: ansible_distribution_major_version|int == 8
 
 - name: Install pywinrm for connecting to windows hosts
   pip:
@@ -183,4 +222,3 @@
   command: git config --global credential.helper 'cache --timeout=86400'
 
 - include_tasks: setup.yml
-

--- a/roles/ansible-tower/tasks/setup.yml
+++ b/roles/ansible-tower/tasks/setup.yml
@@ -16,14 +16,14 @@
 
 - name: download tower installer
   get_url:
-    url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ towerversion }}.tar.gz
-    dest: /tmp/ansible-tower-setup-{{ towerversion }}.tar.gz
+    url: https://releases.ansible.com/ansible-tower/setup-bundle/ansible-tower-setup-bundle-{{ towerversion }}.el{{ ansible_distribution_major_version }}.tar.gz
+    dest: /tmp/ansible-tower-setup-bundle-{{ towerversion }}.el{{ ansible_distribution_major_version }}.tar.gz
     mode: 0640
   when: towerchk not in towerversion
 
 - name: extract installer
   unarchive:
-    src: /tmp/ansible-tower-setup-{{ towerversion }}.tar.gz
+    src: /tmp/ansible-tower-setup-bundle-{{ towerversion }}.el{{ ansible_distribution_major_version }}.tar.gz
     dest: /tmp/
     remote_src: True
   when: towerchk not in towerversion
@@ -31,11 +31,11 @@
 - name: template inventory file
   template:
     src: inventory
-    dest: /tmp/ansible-tower-setup-{{ towerversion }}/inventory
+    dest: /tmp/ansible-tower-setup-bundle-{{ towerversion }}.el{{ ansible_distribution_major_version }}/inventory
   when: towerchk != towerversion
 
 - name: run the tower installer
-  shell: ./setup.sh chdir=/tmp/ansible-tower-setup-{{ towerversion }}
+  shell: ./setup.sh chdir=/tmp/ansible-tower-setup-bundle-{{ towerversion }}.el{{ ansible_distribution_major_version }}
   when: towerchk not in towerversion
 
 - name: wait for tower to be up
@@ -258,5 +258,3 @@
     regexp: 'GIT_SSL_NO_VERIFY'
     line: "AWX_TASK_ENV['GIT_SSL_NO_VERIFY'] = 'True'"
   notify: restart tower
-
-

--- a/roles/docs_nginx/tasks/main.yml
+++ b/roles/docs_nginx/tasks/main.yml
@@ -4,13 +4,27 @@
     src: nginx.repo
     dest: /etc/yum.repos.d/nginx.repo
 
-- name: selinux bindings
-  yum:
+- name: selinux bindings RHEL7
+  package:
     name:
-     - libsemanage-python
-     - libselinux-python
+      - libsemanage-python
+      - libselinux-python
     state: present
-  when: ansible_selinux.status is defined and ansible_selinux.status == "enabled"
+  when:
+    - ansible_selinux.status is defined
+    - ansible_selinux.status == "enabled"
+    - ansible_distribution_major_version|int < 8
+
+- name: selinux bindings RHEL8
+  package:
+    name:
+      - policycoreutils-python-utils
+      - python3-libselinux
+    state: present
+  when:
+    - ansible_selinux.status is defined
+    - ansible_selinux.status == "enabled"
+    - ansible_distribution_major_version|int == 8
 
 - name: install nginx
   yum:

--- a/roles/docs_nginx_ssl/tasks/main.yml
+++ b/roles/docs_nginx_ssl/tasks/main.yml
@@ -4,14 +4,27 @@
     src: nginx.repo
     dest: /etc/yum.repos.d/nginx.repo
 
-- name: selinux bindings
-  yum:
-    name: "{{ item }}"
+- name: selinux bindings RHEL7
+  package:
+    name:
+      - libsemanage-python
+      - libselinux-python
     state: present
-  when: ansible_selinux.status is defined and ansible_selinux.status == "enabled"
-  with_items:
-   - libsemanage-python
-   - libselinux-python
+  when:
+    - ansible_selinux.status is defined
+    - ansible_selinux.status == "enabled"
+    - ansible_distribution_major_version|int < 8
+
+- name: selinux bindings RHEL8
+  package:
+    name:
+      - policycoreutils-python-utils
+      - python3-libselinux
+    state: present
+  when:
+    - ansible_selinux.status is defined
+    - ansible_selinux.status == "enabled"
+    - ansible_distribution_major_version|int == 8
 
 - name: install nginx
   yum:

--- a/roles/docs_setup/handlers/main.yml
+++ b/roles/docs_setup/handlers/main.yml
@@ -7,3 +7,8 @@
   service:
     name: nginx
     state: restarted
+
+- name: restart php-fpm
+  service:
+    name: php-fpm
+    state: restarted

--- a/roles/docs_setup/tasks/main.yml
+++ b/roles/docs_setup/tasks/main.yml
@@ -2,6 +2,13 @@
   yum:
     name: http://rpms.famillecollet.com/enterprise/remi-release-7.rpm
     state: present
+  when: ansible_distribution_major_version|int < 8
+
+- name: Setup Remi PHP 8 Repo
+  yum:
+    name: http://rpms.famillecollet.com/enterprise/remi-release-8.rpm
+    state: present
+  when: ansible_distribution_major_version|int == 8
 
 - name: Install MySQL, PHP, Git
   yum:
@@ -15,7 +22,37 @@
       - rsync
     state: present
     enablerepo: remi-php72
+  when: ansible_distribution_major_version|int < 8
   notify: restart nginx
+
+- name: Install php 7.2 stream on RHEL8
+  dnf:
+    name: '@php:7.2'
+    state: present
+  when: ansible_distribution_major_version|int == 8
+
+- name: Install MySQL, PHP, Git
+  yum:
+    name:
+      - mariadb-server
+      - php-fpm
+      - php-mysqlnd
+      - php-pdo
+      - python36
+      - git
+      - rsync
+    state: present
+    enablerepo: remi-php72
+  when: ansible_distribution_major_version|int == 8
+  notify: restart nginx
+
+- name: Enable TCP port 9000 for php-fpm
+  lineinfile:
+    path: /etc/php-fpm.d/www.conf
+    regexp: '^listen ='
+    line: 'listen = 127.0.0.1:9000'
+  when: ansible_distribution_major_version|int == 8
+  notify: restart php-fpm
 
 - name: Start Services
   service:
@@ -35,14 +72,26 @@
     mode: 0777
     state: directory
 
-- name: Install asciidoc packages (RHEL)
+- name: Install asciidoc packages (RHEL7)
   yum:
     name:
       - asciidoc
       - rubygem-asciidoctor
     state: present
     enablerepo: rhui-REGION-rhel-server-optional
-  when: ansible_distribution == 'RedHat'
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version|int < 8
+    - instance_loc == 'ec2'
+
+- name: Install asciidoc packages (RHEL8)
+  yum:
+    name:
+      - asciidoc
+    state: present
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version|int == 8
 
 - name: Install asciidoc packages (CentOS)
   yum:
@@ -80,6 +129,17 @@
         src: docs/decks/
         dest: /usr/share/nginx/html/decks/
 
+- name: Find existing HTML docs
+  find:
+    paths: /usr/share/nginx/html
+    file_type: file
+    use_regex: yes
+    patterns:
+      - '^index.html$'
+      - '^wrapup.html$'
+      - '^exercise[1-7].html$'
+  register: lab_guide_html_files
+
 - name: Build HTML Docs
   command: asciidoc -d book -v -o {{ item }}.html {{ item }}.adoc
   args:
@@ -94,7 +154,7 @@
     - exercise5
     - exercise6
     - exercise7
-  when: copycontent.changed
+  when: copycontent.changed or lab_guide_html_files.matched != 9
 
 - name: Create users directory on server
   file:

--- a/roles/linux-common/tasks/main.yml
+++ b/roles/linux-common/tasks/main.yml
@@ -12,9 +12,16 @@
 - name: Remove PeerDNS=yes entry
   lineinfile:
     path: "{{ item }}"
-    regexp: '^PEERDNS=yes'
-    line: ''
+    regexp: '^PEERDNS='
+    line: 'PEERDNS=no'
   with_items: "{{ eths.stdout_lines }}"
+  register: ifcfg
+
+- name: set DNS resolution in resolv.conf file
+  template:
+    src: templates/resolv.conf.j2
+    dest: /etc/resolv.conf
+  register: etchost
 
 - name: set DNS resolution in ifcfg file
   blockinfile:
@@ -26,11 +33,22 @@
   register: dnschange
   with_items: "{{ eths.stdout_lines }}"
 
-- name: set DNS resolution in resolv.conf file
-  template:
-    src: templates/resolv.conf.j2
-    dest: /etc/resolv.conf
-  register: etchost
+- name: create dhclient.conf
+  file:
+    path: /etc/dhcp/dhclient.conf
+    state: touch
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: set custom DNS server
+  blockinfile:
+    dest: /etc/dhcp/dhclient.conf
+    block: |
+      prepend domain-name-servers {{ hostvars['windc']['private_ip'] }};
+      prepend domain-search "{{ dns_domain_name }}", "ec2.internal";
+    state: present
+  register: dnschange
 
 - name: restart NetworkManager
   service:

--- a/roles/linux-common/tasks/main.yml
+++ b/roles/linux-common/tasks/main.yml
@@ -54,7 +54,7 @@
   service:
     name: NetworkManager
     state: restarted
-  when: dnschange.changed or etchost.changed
+  when: dnschange.changed or ifcfg.changed
 
 - name: Add EPEL repo
   yum_repository:

--- a/roles/linux-common/tasks/main.yml
+++ b/roles/linux-common/tasks/main.yml
@@ -12,16 +12,9 @@
 - name: Remove PeerDNS=yes entry
   lineinfile:
     path: "{{ item }}"
-    regexp: '^PEERDNS='
-    line: 'PEERDNS=no'
+    regexp: '^PEERDNS=yes'
+    line: ''
   with_items: "{{ eths.stdout_lines }}"
-  register: ifcfg
-
-- name: set DNS resolution in resolv.conf file
-  template:
-    src: templates/resolv.conf.j2
-    dest: /etc/resolv.conf
-  register: etchost
 
 - name: set DNS resolution in ifcfg file
   blockinfile:
@@ -33,28 +26,17 @@
   register: dnschange
   with_items: "{{ eths.stdout_lines }}"
 
-- name: create dhclient.conf
-  file:
-    path: /etc/dhcp/dhclient.conf
-    state: touch
-    owner: root
-    group: root
-    mode: '0644'
-
-- name: set custom DNS server
-  blockinfile:
-    dest: /etc/dhcp/dhclient.conf
-    block: |
-      prepend domain-name-servers {{ hostvars['windc']['private_ip'] }};
-      prepend domain-search "{{ dns_domain_name }}", "ec2.internal";
-    state: present
-  register: dnschange
+- name: set DNS resolution in resolv.conf file
+  template:
+    src: templates/resolv.conf.j2
+    dest: /etc/resolv.conf
+  register: etchost
 
 - name: restart NetworkManager
   service:
     name: NetworkManager
     state: restarted
-  when: dnschange.changed or ifcfg.changed
+  when: dnschange.changed or etchost.changed
 
 - name: Add EPEL repo
   yum_repository:
@@ -63,6 +45,30 @@
     baseurl: https://dl.fedoraproject.org/pub/epel/7/x86_64/
     enabled: yes
     gpgcheck: no
+  when: ansible_distribution_major_version|int < 8
+
+- name: Add EPEL repo for RHEL7
+  yum_repository:
+    name: epel
+    description: EPEL for Enterprise Linux 8
+    baseurl: https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/
+    enabled: yes
+    gpgcheck: no
+  when: ansible_distribution_major_version|int == 8
+
+- name: Enable optional repos for RHEL8
+  command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-REGION-rhel-server-optional
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version|int < 8
+    - instance_loc == 'ec2'
+
+- name: Enable appstream repo (non-ec2)
+  command: yum-config-manager --enable rhel-8-for-x86_64-appstream-rpms
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version|int == 8
+    - instance_loc != 'ec2'
 
 - name: Enable optional repos
   command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-REGION-rhel-server-optional
@@ -74,4 +80,3 @@
       - vim
       - bind-utils
     state: present
-

--- a/roles/manage-ec2-instances/tasks/find_ami_ids.yml
+++ b/roles/manage-ec2-instances/tasks/find_ami_ids.yml
@@ -7,6 +7,14 @@
     region: "{{ ec2_region }}"
   register: rhel7_ami_find
 
+- name: find ami id for rhel 8
+  ec2_ami_facts:
+    owners: 309956199498
+    filters:
+      name: "{{ ec2_image_names['rhel8'] }}"
+    region: "{{ ec2_region }}"
+  register: rhel8_ami_find
+
 - name: find ami for windows 2016 core
   ec2_ami_facts:
     filters:
@@ -39,6 +47,7 @@
   set_fact:
     ec2_ami_ids:
       rhel7: "{{ rhel7_ami_find.images[-1].image_id | default('') }}"
+      rhel8: "{{ rhel8_ami_find.images[-1].image_id | default('') }}"
       win2016_core: "{{ win2016_core_ami_find.images[-1].image_id | default('') }}"
       win2016_full: "{{ win2016_full_ami_find.images[-1].image_id | default('') }}"
       win2019_core: "{{ win2019_core_ami_find.images[-1].image_id | default('') }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,7 +20,7 @@ users_password: "Ans1bl3--"
 
 # Tower Admin Password
 towerpass: "MyPassw0rd21"
-towerversion: 3.4.2-1
+towerversion: 3.5.2-1
 pgpass: awx
 rabbitpass: tower
 
@@ -93,7 +93,8 @@ ec2_region: "us-east-1"
 
 # Internal lookup dict for image names and types
 ec2_image_names:
-  rhel7: "RHEL-7.6_HVM_GA*"
+  rhel7: "RHEL-7.6_HVM_GA*x86_64*"
+  rhel8: "RHEL-8.0.0_HVM_GA*x86_64*"
   win2016_core: "Windows_Server-2016-English-Core-Base*"
   win2016_full: "Windows_Server-2016-English-Full-Base*"
   win2019_core: "Windows_Server-2019-English-Core-Base*"


### PR DESCRIPTION
This adds initial support for RHEL8. Currently only available on EC2 as CentOS 8 hasn't GA yet.

- gitlab node is not yet working on RHEL8 as soon as gitlab-ce package is available we should expect it to work
- tower and docs nodes work without issues
- RHEL8 support is available on Tower 3.5.x, you need to set the tower_version to 3.5.0-1 or higher to be able to use RHEL8 on tower node. In this PR, latest version is set 3.5.2-1 and tested with.

Default is still set to RHEL7, set the following variables to use RHEL8 on Tower and docs nodes:

ec2_tower_instance_ami_type: rhel8
ec2_docs_instance_ami_type: rhel8