### PR TITLE
Vagrant support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,290 @@
+$script = <<-SCRIPT
+& $([scriptblock]::Create((New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))) -ForceNewSSLCert -EnableCredSSP
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  # Define the number of nodes to start
+
+  nid = 6
+
+  gitlab_hostname= "gitlab"
+  nid = (nid - 1)
+  config.vm.define "#{gitlab_hostname}" do |node|
+    node.vm.box = "centos/7"
+    node.vm.hostname = "#{gitlab_hostname}"
+    node.vm.boot_timeout = 600
+    node.ssh.insert_key = false
+    node.vm.network :private_network, ip: "10.0.1.4"
+
+    node.vm.provider "virtualbox" do |vb, override|
+      vb.gui = false
+      vb.name = "#{gitlab_hostname}"
+      vb.customize ["modifyvm", :id, "--memory", 3072]
+      vb.customize ["modifyvm", :id, "--cpus", 2]
+    end
+
+    node.vm.provider "kvm" do |kvm, override|
+      kvm.memory_size = "3072m"
+    end
+
+    node.vm.provider :libvirt do |libvirt, override|
+      libvirt.memory = 3072
+      libvirt.nested = true
+    end
+
+    node.vm.provider :vmware_desktop do |v, override|
+      v.gui = false
+      v.vmx["memsize"] = "3072"
+      v.vmx["numvcpus"] = "2"
+      v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+      v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+      v.vmx["RemoteDisplay.vnc.port"] = "5900"
+      v.enable_vmrun_ip_lookup = false
+    end
+  end
+
+  docs_hostname= "docs"
+  nid = (nid - 1)
+  config.vm.define "#{docs_hostname}" do |node|
+    node.vm.box = "centos/7"
+    node.vm.hostname = "#{docs_hostname}"
+    node.vm.boot_timeout = 600
+    node.ssh.insert_key = false
+    node.vm.network "forwarded_port", guest: 80, host: 80
+    node.vm.network :private_network, ip: "10.0.1.5"
+
+    node.vm.provider "virtualbox" do |vb, override|
+      vb.gui = false
+      vb.name = "#{docs_hostname}"
+      vb.customize ["modifyvm", :id, "--memory", 2048]
+      vb.customize ["modifyvm", :id, "--cpus", 2]
+    end
+
+    node.vm.provider "kvm" do |kvm, override|
+      kvm.memory_size = "2048m"
+    end
+
+    node.vm.provider :libvirt do |libvirt, override|
+      libvirt.memory = 2048
+      libvirt.nested = true
+    end
+
+    node.vm.provider :vmware_desktop do |v, override|
+        v.gui = false
+        v.vmx["memsize"] = "2048"
+        v.vmx["numvcpus"] = "2"
+        v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.enable_vmrun_ip_lookup = false
+    end
+  end
+
+  windc_hostname= "windc"
+  nid = (nid - 1)
+  config.vm.define "#{windc_hostname}" do |node|
+    node.vm.box = "oatakan/windows-2019-standard-core"
+    node.vm.hostname = "#{windc_hostname}"
+    node.vm.boot_timeout = 600
+    node.winrm.transport = :negotiate
+    node.vm.communicator = "winrm"
+    node.winrm.basic_auth_only = false
+    node.winrm.timeout = 300
+    node.winrm.retry_limit = 20
+    node.vm.network "forwarded_port", guest: 5986, host: 5902
+    node.vm.network :private_network, ip: "10.0.1.6"
+    node.vm.synced_folder ".", "/vagrant", disabled: true
+
+    node.vm.provider "virtualbox" do |vb, override|
+      vb.gui = false
+      vb.name = "#{windc_hostname}"
+      vb.default_nic_type = "82545EM"
+      vb.customize ["modifyvm", :id, "--memory", 4096]
+      vb.customize ["modifyvm", :id, "--cpus", 2]
+      vb.customize ["modifyvm", :id, "--vram", "32"]
+      vb.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
+    end
+
+    node.vm.provider "kvm" do |kvm, override|
+      kvm.memory_size = "4096m"
+    end
+
+    node.vm.provider :libvirt do |libvirt, override|
+      libvirt.memory = 4096
+      libvirt.nested = true
+    end
+
+    node.vm.provider :vmware_desktop do |v, override|
+        v.gui = false
+        v.vmx["memsize"] = "4096"
+        v.vmx["numvcpus"] = "2"
+        v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.vmx["scsi0.virtualDev"] = "lsisas1068"
+        v.enable_vmrun_ip_lookup = false
+    end
+  end
+
+  s1_tower_hostname= "s1-tower"
+  nid = (nid - 1)
+  config.vm.define "#{s1_tower_hostname}" do |node|
+    node.vm.box = "centos/7"
+    node.vm.hostname = "#{s1_tower_hostname}"
+    node.vm.boot_timeout = 600
+    node.ssh.insert_key = false
+    node.vm.network :private_network, ip: "10.0.1.7"
+
+    node.vm.provider "virtualbox" do |vb, override|
+      vb.gui = false
+      vb.name = "#{s1_tower_hostname}"
+      vb.customize ["modifyvm", :id, "--memory", 4096]
+      vb.customize ["modifyvm", :id, "--cpus", 2]
+    end
+
+    node.vm.provider "kvm" do |kvm, override|
+      kvm.memory_size = "4096m"
+    end
+
+    node.vm.provider :libvirt do |libvirt, override|
+      libvirt.memory = 4096
+      libvirt.nested = true
+    end
+
+    node.vm.provider :vmware_desktop do |v, override|
+        v.gui = false
+        v.vmx["memsize"] = "4096"
+        v.vmx["numvcpus"] = "2"
+        v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.enable_vmrun_ip_lookup = false
+    end
+  end
+
+  s1_win1_hostname= "s1-win1"
+  nid = (nid - 1)
+  config.vm.define "#{s1_win1_hostname}" do |node|
+    node.vm.box = "oatakan/windows-2019-standard-core"
+    node.vm.hostname = "#{s1_win1_hostname}"
+    node.vm.boot_timeout = 600
+    node.winrm.transport = :negotiate
+    node.vm.communicator = "winrm"
+    node.winrm.basic_auth_only = false
+    node.winrm.timeout = 300
+    node.winrm.retry_limit = 20
+    node.vm.network "forwarded_port", guest: 5986, host: 5903, auto_correct: true
+    node.vm.network :private_network, ip: "10.0.1.8"
+    node.vm.synced_folder ".", "/vagrant", disabled: true
+
+    node.vm.provider "virtualbox" do |vb, override|
+      vb.gui = false
+      vb.name = "#{s1_win1_hostname}"
+      vb.default_nic_type = "82545EM"
+      vb.customize ["modifyvm", :id, "--memory", 3072]
+      vb.customize ["modifyvm", :id, "--cpus", 2]
+      vb.customize ["modifyvm", :id, "--vram", "32"]
+      vb.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
+    end
+
+    node.vm.provider "kvm" do |kvm, override|
+      kvm.memory_size = "3072m"
+    end
+
+    node.vm.provider :libvirt do |libvirt, override|
+      libvirt.memory = 3072
+      libvirt.nested = true
+    end
+
+    node.vm.provider :vmware_desktop do |v, override|
+        v.gui = false
+        v.vmx["memsize"] = "3072"
+        v.vmx["numvcpus"] = "2"
+        v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.vmx["scsi0.virtualDev"] = "lsisas1068"
+        v.enable_vmrun_ip_lookup = false
+    end
+  end
+
+  s1_work_hostname= "s1-work"
+  nid = (nid - 1)
+  config.vm.define "#{s1_work_hostname}" do |node|
+    node.vm.box = "oatakan/windows-2019-standard"
+    node.vm.hostname = "#{s1_work_hostname}"
+    node.vm.boot_timeout = 600
+    node.winrm.transport = :negotiate
+    node.vm.communicator = "winrm"
+    node.winrm.basic_auth_only = false
+    node.winrm.timeout = 300
+    node.winrm.retry_limit = 20
+    node.vm.network "forwarded_port", guest: 3389, host: 13389, auto_correct: true
+    node.vm.network "forwarded_port", guest: 5986, host: 5904, auto_correct: true
+    node.vm.network :private_network, ip: "10.0.1.9"
+    node.vm.synced_folder ".", "/vagrant", disabled: true
+
+    node.vm.provider "virtualbox" do |vb, override|
+      vb.gui = false
+      vb.name = "#{s1_work_hostname}"
+      vb.default_nic_type = "82545EM"
+      vb.customize ["modifyvm", :id, "--memory", 3072]
+      vb.customize ["modifyvm", :id, "--cpus", 2]
+      vb.customize ["modifyvm", :id, "--vram", "32"]
+      vb.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
+    end
+
+    node.vm.provider "kvm" do |kvm, override|
+      kvm.memory_size = "3072m"
+    end
+
+    node.vm.provider :libvirt do |libvirt, override|
+      libvirt.memory = 3072
+      libvirt.nested = true
+    end
+
+    node.vm.provider :vmware_desktop do |v, override|
+        v.gui = false
+        v.vmx["memsize"] = "3072"
+        v.vmx["numvcpus"] = "2"
+        v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.vmx["scsi0.virtualDev"] = "lsisas1068"
+        v.enable_vmrun_ip_lookup = false
+    end
+
+    if Vagrant::Util::Platform.windows?
+      config.vm.provision "shell", inline: $script
+    end
+
+    if nid == 0
+      node.vm.provision "ansible" do |ansible|
+        ansible.limit = "all,localhost"
+        ansible.playbook = "provision.yml"
+        ansible.config_file = "ansible.cfg"
+        ansible.compatibility_mode = "2.0"
+        ansible.host_vars = {
+          "gitlab" => {"private_ip" => "10.0.1.4"},
+          "docs" => {"private_ip" => "10.0.1.5"},
+          "windc" => {"private_ip" => "10.0.1.6"},
+          "s1-tower" => {"private_ip" => "10.0.1.7"},
+          "s1-win1" => {"private_ip" => "10.0.1.8"},
+          "s1-work" => {"private_ip" => "10.0.1.9"}
+        }
+        ansible.groups = {
+
+          "all:vars" => { "ansible_winrm_scheme" => "http" }
+        }
+        ansible.extra_vars = {
+          instance_loc: "vagrant",
+          user_count: 1,
+          user_prefix: "student",
+          root_user: "vagrant",
+          root_password: "vagrant",
+          name_prefix: "vg"
+        }
+      end
+    end
+  end
+end

--- a/roles/manage-vagrant-instances/tasks/add_hosts.yml
+++ b/roles/manage-vagrant-instances/tasks/add_hosts.yml
@@ -1,0 +1,78 @@
+---
+- name: DomainController | Add new instance to host group
+  add_host:
+    hostname: "windc"
+    ansible_host: "{{ hostvars['windc'].ansible_host }}"
+    ansible_port: "{{ hostvars['windc'].ansible_port }}"
+    ansible_user: "Administrator"
+    ansible_password: "{{ domain_admin_password }}"
+    ansible_connection: "winrm"
+    private_ip: "{{ hostvars['windc'].private_ip }}"
+    ansible_winrm_transport: "basic"
+    ansible_winrm_server_cert_validation: "ignore"
+    groups: windows_domain_controllers
+
+- name: GitLab | Add new instance to host group
+  add_host:
+    hostname: "gitlab"
+    ansible_ssh_host: "{{ hostvars['gitlab'].ansible_host }}"
+    ansible_host: "{{ hostvars['gitlab'].ansible_host }}"
+    ansible_port: "{{ hostvars['gitlab'].ansible_port }}"
+    private_ip: "{{ hostvars['gitlab'].private_ip }}"
+    ansible_user: "{{ root_user }}"
+    ansible_password: "{{ root_password }}"
+    groups: gitlab
+
+- name: Docs | Add new instance to host group
+  add_host:
+    hostname: "docs"
+    ansible_ssh_host: "{{ hostvars['docs'].ansible_host }}"
+    ansible_host: "{{ hostvars['docs'].ansible_host }}"
+    ansible_port: "{{ hostvars['docs'].ansible_port }}"
+    private_ip: "{{ hostvars['docs'].private_ip }}"
+    public_ip: "{{ hostvars['docs'].ansible_host }}"
+    ansible_user: "{{ root_user }}"
+    ansible_password: "{{ root_password }}"
+    groups: docs
+
+- name: Tower | Add new instance to host group
+  add_host:
+    hostname: "{{ hostvars['s1-tower'].inventory_hostname | replace(name_prefix + '-', '') }}"
+    ansible_ssh_host: "{{ hostvars['s1-tower'].ansible_host }}"
+    ansible_host: "{{ hostvars['s1-tower'].ansible_host }}"
+    ansible_port: "{{ hostvars['s1-tower'].ansible_port }}"
+    private_ip: "{{ hostvars['s1-tower'].private_ip }}"
+    ansible_user: "{{ root_user }}"
+    ansible_password: "{{ root_password }}"
+    tower_license: "{{ tower_license }}"
+    student: "{{ hostvars['s1-tower'].inventory_hostname | replace(name_prefix + '-', '') | regex_replace('[^0-9]', '') }}"
+    groups: tower
+
+- name: Windows | Add new instance to host group
+  add_host:
+    hostname: "{{ hostvars['s1-win1'].inventory_hostname | replace(name_prefix + '-', '') }}"
+    ansible_host: "{{ hostvars['s1-win1'].ansible_host }}"
+    student: "{{ hostvars['s1-win1'].inventory_hostname | replace(name_prefix + '-', '') | regex_replace('[^0-9]', '') }}"
+    private_ip: "{{ hostvars['s1-win1'].private_ip }}"
+    ansible_port: "{{ hostvars['s1-win1'].ansible_port }}"
+    ansible_user: "Administrator"
+    ansible_password: "{{ domain_admin_password }}"
+    ansible_connection: "winrm"
+    ansible_winrm_transport: "basic"
+    ansible_winrm_server_cert_validation: "ignore"
+    groups: windows
+
+- name: Workstation | Add new instance to host group
+  add_host:
+    hostname: "{{ hostvars['s1-work'].inventory_hostname | replace(name_prefix + '-', '') }}"
+    private_ip: "{{ hostvars['s1-work'].private_ip }}"
+    ansible_host: "{{ hostvars['s1-work'].ansible_host }}"
+    student: "{{ hostvars['s1-work'].inventory_hostname | replace(name_prefix + '-', '') | regex_replace('[^0-9]', '') }}"
+    ansible_port: "{{ hostvars['s1-work'].ansible_port }}"
+    ansible_user: "Administrator"
+    ansible_password: "{{ domain_admin_password }}"
+    ansible_become_password: "{{ users_password }}"
+    ansible_connection: "winrm"
+    ansible_winrm_transport: "basic"
+    ansible_winrm_server_cert_validation: "ignore"
+    groups: windows_workstations

--- a/roles/manage-vagrant-instances/tasks/generate_inventory.yml
+++ b/roles/manage-vagrant-instances/tasks/generate_inventory.yml
@@ -1,0 +1,11 @@
+---
+- name: Generate instructor inventory
+  template:
+    src: instructor_inventory.j2
+    dest: "{{ playbook_dir }}/workshops/{{ name_prefix }}/instructor_inventory.txt"
+
+- name: Generate student inventories
+  template:
+    src: instances.txt.j2
+    dest: "{{ playbook_dir }}/workshops/{{ name_prefix }}/{{ user_prefix }}{{ item }}-instances.txt"
+  with_sequence: count="{{ user_count }}"

--- a/roles/manage-vagrant-instances/tasks/main.yml
+++ b/roles/manage-vagrant-instances/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# add hosts to groups
+- include_tasks: add_hosts.yml
+
+# wait for instances to come online
+- include_tasks: wait_for_connection.yml
+
+# reset Administrator password on Windows nodes
+- include_tasks: reset_admin_pwd.yml
+  vars:
+    ansible_user: "{{ root_user }}"
+    ansible_password: "{{ root_password }}"
+
+# set private addresses on Windows nodes for vmware_desktop provider as vagrant doesn't set this up
+- include_tasks: set_private_ip.yml
+  loop_control:
+    loop_var: server_item
+  vars:
+    private_ip: "{{ hostvars[server_item].private_ip }}"
+  with_items:
+    - "{{ groups['windows_domain_controllers'] }}"
+    - "{{ groups['windows'] }}"
+    - "{{ groups['windows_workstations'] }}"
+
+#- include_tasks: set_private_ip_all.yml
+
+# generate local inventory files
+- include_tasks: generate_inventory.yml

--- a/roles/manage-vagrant-instances/tasks/reset_admin_pwd.yml
+++ b/roles/manage-vagrant-instances/tasks/reset_admin_pwd.yml
@@ -1,0 +1,27 @@
+---
+- name: Update Administrator pwd
+  win_user:
+    name: Administrator
+    password: "{{ domain_admin_password }}"
+    state: present
+  delegate_to: "{{ item }}"
+  with_items:
+    - "{{ groups['windows_domain_controllers'] }}"
+
+- name: Update Administrator pwd
+  win_user:
+    name: Administrator
+    password: "{{ domain_admin_password }}"
+    state: present
+  delegate_to: "{{ item }}"
+  with_items:
+    - "{{ groups['windows'] }}"
+
+- name: Update Administrator pwd
+  win_user:
+    name: Administrator
+    password: "{{ domain_admin_password }}"
+    state: present
+  delegate_to: "{{ item }}"
+  with_items:
+    - "{{ groups['windows_workstations'] }}"

--- a/roles/manage-vagrant-instances/tasks/set_private_ip.yml
+++ b/roles/manage-vagrant-instances/tasks/set_private_ip.yml
@@ -1,0 +1,24 @@
+---
+- block:
+    - name: Gather hardware information
+      setup:
+        gather_subset:
+          - '!all'
+          - '!any'
+          - hardware
+
+    - name: Install required module
+      win_psmodule:
+        name: NetworkingDsc
+        state: present
+      when: "'VMware' in hostvars[server_item].ansible_product_name"
+
+    - name: Set ip address
+      win_dsc:
+        resource_name: IPAddress
+        IPAddress: "{{ private_ip }}"
+        InterfaceAlias: 'Ethernet1'
+        AddressFamily: 'IPV4'
+      when: "'VMware' in hostvars[server_item].ansible_product_name"
+  delegate_to: "{{ server_item }}"
+  delegate_facts: yes

--- a/roles/manage-vagrant-instances/tasks/set_private_ip_all.yml
+++ b/roles/manage-vagrant-instances/tasks/set_private_ip_all.yml
@@ -1,0 +1,37 @@
+---
+- name: Gather hardware information
+  setup:
+    gather_subset:
+      - '!all'
+      - '!any'
+      - hardware
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups['windows_domain_controllers'] }}"
+    - "{{ groups['windows'] }}"
+    - "{{ groups['windows_workstations'] }}"
+
+- name: Install required module
+  win_psmodule:
+    name: NetworkingDsc
+    state: present
+  delegate_to: "{{ item }}"
+  when: "'VMware' in hostvars[item].ansible_product_name"
+  with_items:
+    - "{{ groups['windows_domain_controllers'] }}"
+    - "{{ groups['windows'] }}"
+    - "{{ groups['windows_workstations'] }}"
+
+- name: Set ip address
+  win_dsc:
+    resource_name: IPAddress
+    IPAddress: "{{ hostvars[item].private_ip }}"
+    InterfaceAlias: 'Ethernet1'
+    AddressFamily: 'IPV4'
+  delegate_to: "{{ item }}"
+  when: "'VMware' in hostvars[item].ansible_product_name"
+  with_items:
+    - "{{ groups['windows_domain_controllers'] }}"
+    - "{{ groups['windows'] }}"
+    - "{{ groups['windows_workstations'] }}"

--- a/roles/manage-vagrant-instances/tasks/wait_for_connection.yml
+++ b/roles/manage-vagrant-instances/tasks/wait_for_connection.yml
@@ -1,0 +1,19 @@
+---
+- name: Wait for connection on all linux nodes
+  wait_for_connection:
+  delegate_to: "{{ item }}"
+  with_items:
+    - "{{ groups['tower'] }}"
+    - "{{ groups['gitlab'] }}"
+    - "{{ groups['docs'] }}"
+
+- name: Wait for connection on all windows nodes
+  wait_for_connection:
+  delegate_to: "{{ item }}"
+  vars:
+    ansible_user: "{{ root_user }}"
+    ansible_password: "{{ root_password }}"
+  with_items:
+    - "{{ groups['windows_domain_controllers'] }}"
+    - "{{ groups['windows'] }}"
+    - "{{ groups['windows_workstations'] }}"

--- a/roles/manage-vagrant-instances/templates/instances.txt.j2
+++ b/roles/manage-vagrant-instances/templates/instances.txt.j2
@@ -1,0 +1,56 @@
+### Inventory for {{ user_prefix + item }} ###
+[all:vars]
+{% if ssh_port is defined %}
+ansible_port={{ ssh_port }}
+{% endif %}
+
+[windows:vars]
+ansible_connection=winrm
+ansible_winrm_transport=basic
+ansible_winrm_server_cert_validation=ignore
+ansible_port=5986
+
+[windows_workstations:vars]
+ansible_connection=winrm
+ansible_winrm_transport=basic
+ansible_winrm_server_cert_validation=ignore
+ansible_port=5986
+
+[tower:vars]
+ansible_port=22
+ansible_ssh_user={{ root_user }}
+
+[{{ user_prefix }}{{ item }}]
+{% for host in hostvars %}
+{%   if "s" + item + "-" in host -%}
+{%     if "windc" in host -%}
+{%     elif "gitlab" in host -%}
+{%     elif "docs" in host -%}
+{%     elif "tower" in host %}
+{{ host|replace(name_prefix + "-", "") }} ansible_host={{ hostvars[host].ansible_ssh_host }} 
+{%     else %}
+{{ host|replace(name_prefix + "-", "") }} ansible_host={{ hostvars[host].ansible_host }} ansible_user={{ hostvars[host].ansible_user }}  ansible_password={{ hostvars[host].ansible_password }}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+
+{% for group in groups %}
+{%   if "gitlab" in group -%}
+{%   elif "windows_domain_controllers" in group -%}
+{%   elif "docs" in group -%}
+{%   else %}
+[{{group}}]
+{%   endif %}
+{%   for entry in groups[group] %}
+{%     for host in hostvars %}
+{%       if entry == host and "s" + item + "-" in host %}
+{%         if "windc" in host -%}
+{%         elif "gitlab" in host -%}
+{%         else %}
+{{ host|replace(name_prefix + "-", "") }} 
+{%         endif %}
+{%       endif %}
+{%     endfor %}
+{%   endfor %}
+{% endfor %}
+

--- a/roles/manage-vagrant-instances/templates/instructor_inventory.j2
+++ b/roles/manage-vagrant-instances/templates/instructor_inventory.j2
@@ -1,0 +1,75 @@
+[all:vars]
+{% if ssh_port is defined %}
+ansible_port={{ ssh_port }}
+{% endif %}
+
+[windows:vars]
+ansible_connection=winrm
+ansible_winrm_transport=basic
+ansible_winrm_server_cert_validation=ignore
+ansible_port=5986
+
+[windows_workstations:vars]
+ansible_connection=winrm
+ansible_winrm_transport=basic
+ansible_winrm_server_cert_validation=ignore
+ansible_port=5986
+ansible_become_password={{ users_password }}
+
+[windows_domain_controllers:vars]
+ansible_connection=winrm
+ansible_winrm_transport=basic
+ansible_winrm_server_cert_validation=ignore
+ansible_port=5986
+
+[tower:vars]
+ansible_port=22
+ansible_ssh_user={{ root_user }}
+
+[gitlab:vars]
+ansible_port=22
+ansible_ssh_user={{ root_user }}
+
+[docs:vars]
+ansible_port=22
+ansible_ssh_user={{ root_user }}
+
+
+[instructor]
+{% for host in hostvars %}
+{%   if "windc" in host %}
+{{ host }} ansible_host={{ hostvars[host].ansible_host }} ansible_user={{ hostvars[host].ansible_user }} ansible_password="{{ hostvars[host].ansible_password }}" private_ip={{ hostvars[host].private_ip }}
+{%   elif "gitlab" in host %}
+{{ host }} ansible_host={{ hostvars[host].ansible_ssh_host }} ansible_user={{ hostvars[host].ansible_user }} ansible_password="{{ hostvars[host].ansible_password }}"
+{%   elif "docs" in host %}
+{{ host }} ansible_host={{ hostvars[host].ansible_ssh_host }} ansible_user={{ hostvars[host].ansible_user }} ansible_password="{{ hostvars[host].ansible_password }}"
+{%   endif %}
+{% endfor %}
+
+{% for user in range(1,user_count + 1) %}
+[{{ user_prefix }}{{ user }}]
+{%   for host in hostvars %}
+{%     if "s" + user|string + "-" in host -%}
+{%       if "windc" in host -%}
+{%       elif "gitlab" in host -%}
+{%       elif "docs" in host -%}
+{%       elif "tower" in host %}
+{{ host }} ansible_host={{ hostvars[host].ansible_ssh_host }} ansible_user={{ hostvars[host].ansible_user }} ansible_password="{{ hostvars[host].ansible_password }}"
+{%       else %}
+{{ host }} ansible_host={{ hostvars[host].ansible_host }} ansible_user={{ hostvars[host].ansible_user }} ansible_password="{{ hostvars[host].ansible_password }}" student="{{ hostvars[host].student }}"
+{%       endif %}
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+
+{% for group in groups %}
+[{{group}}]
+{%   for entry in groups[group] %}
+{%     for host in hostvars %}
+{%       if entry == host %}
+{{ host }} 
+{%       endif %}
+{%     endfor %}
+{%   endfor %}
+{% endfor %}
+


### PR DESCRIPTION
This PR implements vagrant support for local development and testing. It adds one additional role (manage-vagrant-instances) and does not impose any changes to existing playbooks and roles.

You would need to install Vagrant with a provider (Virtualbox/VMware/libvirt/kvm) with at least 24 GB available memory to be able to do local development. Run 'vagrant up' to test.