### PR TITLE
Tech preview - Windows SSH support (optional)

### DIFF
--- a/roles/manage-azure-instances/tasks/provision.yml
+++ b/roles/manage-azure-instances/tasks/provision.yml
@@ -64,6 +64,7 @@
     public_ip_allocation_method: Dynamic
     virtual_network_name: "{{ azure_virtual_network }}"
     open_ports:
+      - 22    # SSH
       - 5986  # WinRM secure
       - 5985
       - 3389  # RDP
@@ -100,6 +101,7 @@
     virtual_network_name: "{{ azure_virtual_network }}"
     subnet_name: "{{ azure_virtual_subnet }}"
     open_ports:
+      - 22    # SSH
       - 80
       - 8080
       - 443 
@@ -141,6 +143,7 @@
     virtual_network_name: "{{ azure_virtual_network }}"
     subnet_name: "{{ azure_virtual_subnet }}"
     open_ports:
+      - 22    # SSH
       - 5986  # WinRM secure
       - 5985  # WinRM
       - 3389  # RDP
@@ -329,7 +332,7 @@
     publisher: Microsoft.Compute
     virtual_machine_extension_type: CustomScriptExtension
     type_handler_version: 1.9
-    settings: '{"commandToExecute": "powershell.exe -ExecutionPolicy Unrestricted -File CustomScript.ps1 -ForceNewSSLCert -EnableCredSSP", "fileUris": ["https://raw.githubusercontent.com/mgmt-sa-tiger-team/skylight/master/roles/manage-azure-instances/templates/CustomScript.ps1"]}'
+    settings: {"commandToExecute": "powershell.exe -ExecutionPolicy ByPass -EncodedCommand {{ lookup('template', 'custom_script.ps1.j2') | b64encode(encoding='utf-16-le') }}"}
     auto_upgrade_minor_version: true
   with_items: "{{ dc_instances.results }}"
   async: 7200
@@ -347,7 +350,7 @@
     publisher: Microsoft.Compute
     virtual_machine_extension_type: CustomScriptExtension
     type_handler_version: 1.9
-    settings: '{"commandToExecute": "powershell.exe -ExecutionPolicy Unrestricted -File CustomScript.ps1 -ForceNewSSLCert -EnableCredSSP", "fileUris": ["https://raw.githubusercontent.com/mgmt-sa-tiger-team/skylight/master/roles/manage-azure-instances/templates/CustomScript.ps1"]}'
+    settings: {"commandToExecute": "powershell.exe -ExecutionPolicy ByPass -EncodedCommand {{ lookup('template', 'custom_script.ps1.j2') | b64encode(encoding='utf-16-le') }}"}
     auto_upgrade_minor_version: true
   with_items: "{{ workstation_instances.results }}"
   async: 7200
@@ -365,7 +368,7 @@
     publisher: Microsoft.Compute
     virtual_machine_extension_type: CustomScriptExtension
     type_handler_version: 1.9
-    settings: '{"commandToExecute": "powershell.exe -ExecutionPolicy Unrestricted -File CustomScript.ps1 -ForceNewSSLCert -EnableCredSSP", "fileUris": ["https://raw.githubusercontent.com/mgmt-sa-tiger-team/skylight/master/roles/manage-azure-instances/templates/CustomScript.ps1"]}'
+    settings: {"commandToExecute": "powershell.exe -ExecutionPolicy ByPass -EncodedCommand {{ lookup('template', 'custom_script.ps1.j2') | b64encode(encoding='utf-16-le') }}"}
     auto_upgrade_minor_version: true
   with_items: "{{ windows_instances.results }}"
   async: 7200
@@ -412,10 +415,11 @@
   add_host:
     hostname: "{{ item.invocation.module_args.tags.DNSName }}"
     ansible_host: "{{ item.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.publicIPAddress.properties.ipAddress }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "{{ azure_admin_user }}"
     ansible_password: "{{ azure_admin_pass }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     private_ip: "{{ item.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.privateIPAddress }}"
     ansible_winrm_transport: "credssp"
     ansible_winrm_server_cert_validation: "ignore"
@@ -427,10 +431,11 @@
     hostname: "{{ item.invocation.module_args.tags.DNSName }}"
     ansible_host: "{{ item.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.publicIPAddress.properties.ipAddress }}"
     private_ip:  "{{ item.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.privateIPAddress }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "{{ azure_admin_user }}"
     ansible_password: "{{ azure_admin_pass }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     ansible_winrm_transport: "credssp"
     ansible_winrm_server_cert_validation: "ignore"
     student: "{{ item.invocation.module_args.tags.Student | regex_replace('[^0-9]', '') }}"
@@ -442,11 +447,12 @@
     hostname: "{{ item.invocation.module_args.tags.DNSName }}"
     ansible_host: "{{ item.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.publicIPAddress.properties.ipAddress }}"
     private_ip:  "{{ item.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.privateIPAddress }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "{{ azure_admin_user }}"
     ansible_password: "{{ azure_admin_pass }}"
     ansible_become_password: "{{ users_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     ansible_winrm_transport: "credssp"
     ansible_winrm_server_cert_validation: "ignore"
     student: "{{ item.invocation.module_args.tags.Student | regex_replace('[^0-9]', '') }}"
@@ -470,17 +476,17 @@
   delegate_to: "{{ item }}"
   with_items: "{{ groups['docs'] }}"  
 
-- name: DomainController | Wait for WinRM to come up
+- name: DomainController | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows_domain_controllers'] }}"  
 
-- name: Windows | Wait for WinRM to come up
+- name: Windows | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows'] }}" 
 
-- name: Workstation | Wait for WinRM to come up
+- name: Workstation | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows_workstations'] }}" 

--- a/roles/manage-azure-instances/templates/CustomScript.ps1
+++ b/roles/manage-azure-instances/templates/CustomScript.ps1
@@ -1,4 +1,0 @@
-netsh advfirewall set allprofiles state off
-Get-ScheduledTask *ngen* | Disable-ScheduledTask
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile C:\ConfigureRemotingForAnsible.ps1
-C:\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert -EnableCredSSP

--- a/roles/manage-azure-instances/templates/custom_script.ps1.j2
+++ b/roles/manage-azure-instances/templates/custom_script.ps1.j2
@@ -1,0 +1,15 @@
+netsh advfirewall set allprofiles state off;
+Get-ScheduledTask *ngen* | Disable-ScheduledTask;
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile C:\ConfigureRemotingForAnsible.ps1;
+C:\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert -EnableCredSSP;
+{% if windows_ansible_connection == 'ssh' %}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+Invoke-WebRequest -Uri '{{ windows_openssh_url }}' -OutFile 'C:\Windows\Temp\OpenSSH-Win64.zip';
+Expand-Archive -LiteralPath 'C:\Windows\Temp\OpenSSH-Win64.zip' -DestinationPath 'C:\Program Files' -ErrorAction SilentlyContinue;
+Rename-Item -Path 'C:\Program Files\OpenSSH-Win64' -NewName 'C:\Program Files\OpenSSH' -ErrorAction SilentlyContinue;
+powershell.exe -ExecutionPolicy Bypass -File 'C:\Program Files\OpenSSH\install-sshd.ps1';
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue;
+netsh advfirewall firewall add rule name=sshd dir=in action=allow protocol=TCP localport=22;
+net start sshd;
+Set-Service sshd -StartupType Automatic -ErrorAction SilentlyContinue;
+{% endif %}

--- a/roles/manage-ec2-instances/tasks/provision.yml
+++ b/roles/manage-ec2-instances/tasks/provision.yml
@@ -177,6 +177,10 @@
       Students: "{{ user_count }}"
     rules:
       - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: "0.0.0.0/0"
+      - proto: tcp
         from_port: 5986
         to_port: 5986
         cidr_ip: "0.0.0.0/0"
@@ -199,6 +203,10 @@
       Skylight: "This was provisioned through the skylight provisioner"
       Students: "{{ user_count }}"
     rules:
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: "0.0.0.0/0"
       - proto: tcp
         from_port: 80
         to_port: 80
@@ -525,10 +533,11 @@
   add_host:
     hostname: "windc"
     ansible_host: "{{ item.item.public_ip }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ item.win_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     private_ip: "{{ item.item.private_ip }}"
     ansible_winrm_transport: "ntlm"
     ansible_winrm_server_cert_validation: "ignore"
@@ -543,11 +552,12 @@
     hostname: "s{{ item.item.tags.Student | regex_replace('[^0-9]', '') }}-win1"
     ansible_host: "{{ item.item.public_ip }}"
     private_ip: "{{ item.item.private_ip }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ item.win_password }}"
     ansible_become_password: "{{ domain_admin_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     ansible_winrm_transport: "ntlm"
     ansible_winrm_server_cert_validation: "ignore"
     ansible_winrm_operation_timeout_sec: 120
@@ -562,11 +572,12 @@
     hostname: "s{{ item.item.tags.Student | regex_replace('[^0-9]', '') }}-work"
     ansible_host: "{{ item.item.public_ip }}"
     private_ip: "{{ item.item.private_ip }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ item.win_password }}"
     ansible_become_password: "{{ users_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     ansible_winrm_transport: "ntlm"
     ansible_winrm_server_cert_validation: "ignore"
     ansible_winrm_operation_timeout_sec: 120
@@ -643,17 +654,17 @@
   delegate_to: "{{ item }}"
   with_items: "{{ groups['docs'] }}"  
 
-- name: DomainController | Wait for WinRM to come up
+- name: DomainController | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows_domain_controllers'] }}"  
 
-- name: Windows | Wait for WinRM to come up
+- name: Windows | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows'] }}" 
 
-- name: Workstation | Wait for WinRM to come up
+- name: Workstation | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows_workstations'] }}" 

--- a/roles/manage-ec2-instances/templates/win_ec2_user_data.j2
+++ b/roles/manage-ec2-instances/templates/win_ec2_user_data.j2
@@ -20,5 +20,18 @@ Set-MpPreference -DisableRealtimeMonitoring $true
 Invoke-WebRequest -Uri https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile C:\ConfigureRemotingForAnsible.ps1
 C:\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert -EnableCredSSP
 
+{% if windows_ansible_connection == 'ssh' %}
+# Enable SSH
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri '{{ windows_openssh_url }}' -OutFile 'C:\Windows\Temp\OpenSSH-Win64.zip'
+Expand-Archive -LiteralPath 'C:\Windows\Temp\OpenSSH-Win64.zip' -DestinationPath 'C:\Program Files' -ErrorAction SilentlyContinue
+Rename-Item -Path 'C:\Program Files\OpenSSH-Win64' -NewName 'C:\Program Files\OpenSSH' -ErrorAction SilentlyContinue
+powershell.exe -ExecutionPolicy Bypass -File "C:\Program Files\OpenSSH\install-sshd.ps1"
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue
+netsh advfirewall firewall add rule name=sshd dir=in action=allow protocol=TCP localport=22
+net start sshd
+Set-Service sshd -StartupType Automatic -ErrorAction SilentlyContinue
+{% endif %}
+
 Rename-Computer -NewName {{ vm_name }} -Force -Restart
 </powershell>

--- a/roles/manage-ovirt-instances/tasks/provision.yml
+++ b/roles/manage-ovirt-instances/tasks/provision.yml
@@ -317,10 +317,11 @@
   add_host:
     hostname: "windc"
     ansible_host: "{{ item.ansible_facts.ovirt_vms[0].reported_devices[0].ips[0].address }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ domain_admin_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     private_ip: "{{ item.ansible_facts.ovirt_vms[0].reported_devices[0].ips[0].address }}"
     ansible_winrm_transport: "basic"
     ansible_winrm_server_cert_validation: "ignore"
@@ -369,10 +370,11 @@
     ansible_host: "{{ item.ansible_facts.ovirt_vms[0].reported_devices[0].ips[0].address }}"
     student: "{{ item.ansible_facts.ovirt_vms[0].name | replace(name_prefix + '-', '') | regex_replace('[^0-9]', '') }}"
     private_ip: "{{ item.ansible_facts.ovirt_vms[0].reported_devices[0].ips[0].address }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ domain_admin_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     ansible_winrm_transport: "basic"
     ansible_winrm_server_cert_validation: "ignore"
     groups: windows
@@ -384,11 +386,12 @@
     private_ip: "{{ item.ansible_facts.ovirt_vms[0].reported_devices[0].ips[0].address }}"
     ansible_host: "{{ item.ansible_facts.ovirt_vms[0].reported_devices[0].ips[0].address }}"
     student: "{{ item.ansible_facts.ovirt_vms[0].name | replace(name_prefix + '-', '') | regex_replace('[^0-9]', '') }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ domain_admin_password }}"
     ansible_become_password: "{{ users_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     ansible_winrm_transport: "basic"
     ansible_winrm_server_cert_validation: "ignore"
     groups: windows_workstations
@@ -411,17 +414,17 @@
   delegate_to: "{{ item }}"
   with_items: "{{ groups['docs'] }}"  
 
-- name: DomainController | Wait for WinRM to come up
+- name: DomainController | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows_domain_controllers'] }}"  
 
-- name: Windows | Wait for WinRM to come up
+- name: Windows | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows'] }}" 
 
-- name: Workstation | Wait for WinRM to come up
+- name: Workstation | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows_workstations'] }}" 

--- a/roles/manage-ovirt-instances/templates/unattended.xml.j2
+++ b/roles/manage-ovirt-instances/templates/unattended.xml.j2
@@ -70,6 +70,56 @@
                     <Order>5</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
+{% if windows_ansible_connection == 'ssh' %}
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c powershell -Command "Invoke-WebRequest -Uri '{{ windows_openssh_url }}' -OutFile 'C:\Windows\Temp\OpenSSH-Win64.zip'"</CommandLine>
+                    <Description>OpenSSH Install - 1</Description>
+                    <Order>6</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c powershell -Command "Expand-Archive -LiteralPath 'C:\Windows\Temp\OpenSSH-Win64.zip' -DestinationPath 'C:\Program Files' -ErrorAction SilentlyContinue"</CommandLine>
+                    <Description>OpenSSH Install - 2</Description>
+                    <Order>7</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c powershell -Command "Rename-Item -Path 'C:\Program Files\OpenSSH-Win64' -NewName 'C:\Program Files\OpenSSH' -ErrorAction SilentlyContinue"</CommandLine>
+                    <Description>OpenSSH Install - 3</Description>
+                    <Order>8</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c powershell -ExecutionPolicy Bypass -File "C:\Program Files\OpenSSH\install-sshd.ps1"</CommandLine>
+                    <Description>OpenSSH Install - 4</Description>
+                    <Order>9</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c powershell -Command "New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue"</CommandLine>
+                    <Description>OpenSSH Install - 5</Description>
+                    <Order>10</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c "netsh advfirewall firewall add rule name=sshd dir=in action=allow protocol=TCP localport=22"</CommandLine>
+                    <Description>OpenSSH Install - 6</Description>
+                    <Order>11</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c "net start sshd"</CommandLine>
+                    <Description>OpenSSH Install - 7</Description>
+                    <Order>12</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c powershell -Command "Set-Service sshd -StartupType Automatic -ErrorAction SilentlyContinue"</CommandLine>
+                    <Description>OpenSSH Install - 8</Description>
+                    <Order>13</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+{% endif %}
             </FirstLogonCommands>
             <ShowWindowsLive>false</ShowWindowsLive>
         </component>

--- a/roles/manage-vmware-instances/tasks/provision.yml
+++ b/roles/manage-vmware-instances/tasks/provision.yml
@@ -36,6 +36,14 @@
       - winrm set winrm/config/service/auth @{Basic="true"}
       - winrm set winrm/config/service @{AllowUnencrypted="true"}
       - powershell.exe -command "New-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\services\TCPIP6\Parameters -Name DisabledComponents -PropertyType DWord -Value 0xffffffff"
+      - powershell.exe -Command "Invoke-WebRequest -Uri '{{ windows_openssh_url }}' -OutFile 'C:\Windows\Temp\OpenSSH-Win64.zip'"
+      - powershell.exe -Command "Expand-Archive -LiteralPath 'C:\Windows\Temp\OpenSSH-Win64.zip' -DestinationPath 'C:\Program Files' -ErrorAction SilentlyContinue"
+      - powershell.exe -Command "Rename-Item -Path 'C:\Program Files\OpenSSH-Win64' -NewName 'C:\Program Files\OpenSSH' -ErrorAction SilentlyContinue"
+      - powershell.exe -ExecutionPolicy Bypass -File "C:\Program Files\OpenSSH\install-sshd.ps1"
+      - powershell.exe -Command "New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue"
+      - netsh advfirewall firewall add rule name=sshd dir=in action=allow protocol=TCP localport=22
+      - net start sshd
+      - powershell.exe -Command "Set-Service sshd -StartupType Automatic -ErrorAction SilentlyContinue"
   with_sequence: count=1
   register: dc_jobs
   async: 7200
@@ -161,6 +169,14 @@
       - powershell.exe -command "Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
       - winrm set winrm/config/service/auth @{Basic="true"}
       - winrm set winrm/config/service @{AllowUnencrypted="true"}
+      - powershell.exe -Command "Invoke-WebRequest -Uri '{{ windows_openssh_url }}' -OutFile 'C:\Windows\Temp\OpenSSH-Win64.zip'"
+      - powershell.exe -Command "Expand-Archive -LiteralPath 'C:\Windows\Temp\OpenSSH-Win64.zip' -DestinationPath 'C:\Program Files' -ErrorAction SilentlyContinue"
+      - powershell.exe -Command "Rename-Item -Path 'C:\Program Files\OpenSSH-Win64' -NewName 'C:\Program Files\OpenSSH' -ErrorAction SilentlyContinue"
+      - powershell.exe -ExecutionPolicy Bypass -File "C:\Program Files\OpenSSH\install-sshd.ps1"
+      - powershell.exe -Command "New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue"
+      - netsh advfirewall firewall add rule name=sshd dir=in action=allow protocol=TCP localport=22
+      - net start sshd
+      - powershell.exe -Command "Set-Service sshd -StartupType Automatic -ErrorAction SilentlyContinue"
   with_sequence: count={{user_count}}
   register: windows1_jobs
   async: 7200
@@ -204,6 +220,14 @@
       - powershell.exe -command "Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
       - winrm set winrm/config/service/auth @{Basic="true"}
       - winrm set winrm/config/service @{AllowUnencrypted="true"}
+      - powershell.exe -Command "Invoke-WebRequest -Uri '{{ windows_openssh_url }}' -OutFile 'C:\Windows\Temp\OpenSSH-Win64.zip'"
+      - powershell.exe -Command "Expand-Archive -LiteralPath 'C:\Windows\Temp\OpenSSH-Win64.zip' -DestinationPath 'C:\Program Files' -ErrorAction SilentlyContinue"
+      - powershell.exe -Command "Rename-Item -Path 'C:\Program Files\OpenSSH-Win64' -NewName 'C:\Program Files\OpenSSH' -ErrorAction SilentlyContinue"
+      - powershell.exe -ExecutionPolicy Bypass -File "C:\Program Files\OpenSSH\install-sshd.ps1"
+      - powershell.exe -Command "New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue"
+      - netsh advfirewall firewall add rule name=sshd dir=in action=allow protocol=TCP localport=22
+      - net start sshd
+      - powershell.exe -Command "Set-Service sshd -StartupType Automatic -ErrorAction SilentlyContinue"
   with_sequence: count={{user_count}}
   register: workstation_jobs
   async: 7200
@@ -261,10 +285,11 @@
   add_host:
     hostname: "windc"
     ansible_host: "{{ item.ipv4  }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ domain_admin_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     private_ip: "{{ item.ipv4 }}"
     ansible_winrm_transport: "basic"
     ansible_winrm_server_cert_validation: "ignore"
@@ -313,10 +338,11 @@
     ansible_host: "{{ item.ipv4  }}"
     student: "{{ item.hw_name | replace(name_prefix + '-', '') | regex_replace('[^0-9]', '') }}"
     private_ip: "{{ item.ipv4 }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ domain_admin_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     ansible_winrm_transport: "basic"
     ansible_winrm_server_cert_validation: "ignore"
     groups: windows
@@ -328,11 +354,12 @@
     private_ip: "{{ item.ipv4 }}"
     ansible_host: "{{ item.ipv4 }}"
     student: "{{ item.hw_name | replace(name_prefix + '-', '') | regex_replace('[^0-9]', '') }}"
-    ansible_port: 5986
+    ansible_port: "{{ '22' if (windows_ansible_connection is defined and windows_ansible_connection == 'ssh') else '5986' }}"
     ansible_user: "Administrator"
     ansible_password: "{{ domain_admin_password }}"
     ansible_become_password: "{{ users_password }}"
-    ansible_connection: "winrm"
+    ansible_connection: "{{ windows_ansible_connection | default('winrm') }}"
+    ansible_shell_type: "cmd"
     ansible_winrm_transport: "basic"
     ansible_winrm_server_cert_validation: "ignore"
     groups: windows_workstations
@@ -355,17 +382,17 @@
   delegate_to: "{{ item }}"
   with_items: "{{ groups['docs'] }}"  
 
-- name: DomainController | Wait for WinRM to come up
+- name: DomainController | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows_domain_controllers'] }}"  
 
-- name: Windows | Wait for WinRM to come up
+- name: Windows | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows'] }}" 
 
-- name: Workstation | Wait for WinRM to come up
+- name: Workstation | Wait for {{ windows_ansible_connection | default('winrm') }} to come up
   wait_for_connection:
   delegate_to: "{{ item }}"
   with_items: "{{ groups['windows_workstations'] }}" 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -45,6 +45,10 @@ advanced_lab: false
 # Enable nginx-ssl
 nginx_ssl: true
 
+# Experimental - Windows connection variables
+windows_ansible_connection: winrm # set this to winrm/ssh
+windows_openssh_url: https://github.com/PowerShell/Win32-OpenSSH/releases/download/v8.0.0.0p1-Beta/OpenSSH-Win64.zip
+
 ##########################################################
 ###################### GITLAB INFO #######################
 ##########################################################

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -115,7 +115,7 @@ ec2_windc_instance_type: "t3.medium"    # t2.micro fails
 ec2_windc_instance_ami_type: win2019_core # See the ec2_image_names variable for lookup
 ec2_windows_workstation_instance_type: "t3.medium"   # t2.small was slowwwwww...
 # There seems to be an issue using win_chocolatey and win2019_full. See https://github.com/ansible/ansible/issues/47821
-ec2_windows_workstation_instance_ami_type: win2016_full # See the ec2_image_names variable for lookup
+ec2_windows_workstation_instance_ami_type: win2019_full # See the ec2_image_names variable for lookup
 ec2_windows_instance_type: "t3.small"   # Small = 1 vCPU / 2GB
 ec2_windows_instance_ami_type: win2019_core # See the ec2_image_names variable for lookup
 
@@ -202,6 +202,6 @@ azure_rhel_version: "latest"
 
 azure_win_publisher: "MicrosoftWindowsServer"
 azure_win_offer: "WindowsServer"
-azure_win_sku: "2016-Datacenter"
+azure_win_sku: "2019-Datacenter"
 azure_win_version: "latest"
 


### PR DESCRIPTION
This PR adds supports for using SSH for Windows systems only during provisioning. With Ansible 2.8 we now have tech preview support for SSH connections to Windows systems.
It doesn't change any lab exercises. In order to use this feature, you need to set windows_ansible_connection: ssh (default: winrm).
Succesfully tested with all provisioners (except vagrant). It seems to performing very similar to winrm on task-by-task basis. It should potentially improve deploymens with many students.

This PR also improves customization for azure provisioner, remove hardcoded url link to CustomScript and dynamically load from a template.