### PR TITLE
add support for using centos7 image on ec2 (optional)

### DIFF
--- a/roles/manage-ec2-instances/tasks/find_ami_ids.yml
+++ b/roles/manage-ec2-instances/tasks/find_ami_ids.yml
@@ -15,6 +15,14 @@
     region: "{{ ec2_region }}"
   register: rhel8_ami_find
 
+- name: find ami id for centos 7
+  ec2_ami_facts:
+    owners: aws-marketplace
+    filters:
+      name: "{{ ec2_image_names['centos7'] }}"
+    region: "{{ ec2_region }}"
+  register: centos7_ami_find
+
 - name: find ami for windows 2016 core
   ec2_ami_facts:
     filters:
@@ -48,6 +56,7 @@
     ec2_ami_ids:
       rhel7: "{{ rhel7_ami_find.images[-1].image_id | default('') }}"
       rhel8: "{{ rhel8_ami_find.images[-1].image_id | default('') }}"
+      centos7: "{{ centos7_ami_find.images[-1].image_id | default('') }}"
       win2016_core: "{{ win2016_core_ami_find.images[-1].image_id | default('') }}"
       win2016_full: "{{ win2016_full_ami_find.images[-1].image_id | default('') }}"
       win2019_core: "{{ win2019_core_ami_find.images[-1].image_id | default('') }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -99,6 +99,7 @@ ec2_region: "us-east-1"
 ec2_image_names:
   rhel7: "RHEL-7.6_HVM_GA*x86_64*"
   rhel8: "RHEL-8.0.0_HVM_GA*x86_64*"
+  centos7: "CentOS Linux 7 x86_64 HVM EBS ENA 1901_01*"
   win2016_core: "Windows_Server-2016-English-Core-Base*"
   win2016_full: "Windows_Server-2016-English-Full-Base*"
   win2019_core: "Windows_Server-2019-English-Core-Base*"


### PR DESCRIPTION
This PR adds support for using centos7 with ec2. By default we still use rhel7, you need to set the following variables to use centos7:
ec2_docs_instance_ami_type: centos7
ec2_gitlab_instance_ami_type: centos7
ec2_tower_instance_ami_type: centos7
root_user: centos