### PR TITLE
tower-rhel8-ec2-support

### DIFF
--- a/roles/ansible-tower/tasks/setup.yml
+++ b/roles/ansible-tower/tasks/setup.yml
@@ -14,6 +14,31 @@
     towerchk: "{{ checkout.json.version }}"
   when: checkout.json is defined
 
+# this is needed for now since rabbitmq-server version is not compatible with erlang as part of the in Tower 3.5.x installer
+# check again when Tower 3.6.x becomes available to see if its still needed on RHEL 8
+- block:
+    - name: add rabbitmq-server repo for RHEL 8 on ec2 (1/2)
+      yum_repository:
+        name: erlang
+        description: erlang repo
+        file: rabbitmq_server
+        baseurl: https://packagecloud.io/rabbitmq/erlang/el/8/$basearch
+        gpgcheck: no
+        repo_gpgcheck: yes
+        gpgkey: https://packagecloud.io/rabbitmq/erlang/gpgkey
+
+    - name: add rabbitmq-server repo for RHEL 8 on ec2 (2/2)
+      yum_repository:
+        name: rabbitmq_server
+        description: rabbitmq server repo
+        file: rabbitmq_server
+        baseurl: https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.8.x/el/8/
+        enabled: yes
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version|int == 8
+    - instance_loc == 'ec2'
+
 - name: download tower installer
   get_url:
     url: https://releases.ansible.com/ansible-tower/setup-bundle/ansible-tower-setup-bundle-{{ towerversion }}.el{{ ansible_distribution_major_version }}.tar.gz

--- a/roles/linux-common/tasks/main.yml
+++ b/roles/linux-common/tasks/main.yml
@@ -56,16 +56,16 @@
     state: restarted
   when: dnschange.changed or ifcfg.changed
 
-- name: Add EPEL repo
+- name: Add EPEL repo for RHEL 7
   yum_repository:
     name: epel
     description: EPEL for Enterprise Linux 7
     baseurl: https://dl.fedoraproject.org/pub/epel/7/x86_64/
     enabled: yes
     gpgcheck: no
-  when: ansible_distribution_major_version|int < 8
+  when: ansible_distribution_major_version|int == 7
 
-- name: Add EPEL repo for RHEL7
+- name: Add EPEL repo for RHEL 8
   yum_repository:
     name: epel
     description: EPEL for Enterprise Linux 8
@@ -74,23 +74,19 @@
     gpgcheck: no
   when: ansible_distribution_major_version|int == 8
 
-- name: Enable optional repos for RHEL8
+- name: Enable optional repos for RHEL 7 (ec2)
   command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-REGION-rhel-server-optional
   when:
     - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version|int < 8
+    - ansible_distribution_major_version|int == 7
     - instance_loc == 'ec2'
 
-- name: Enable appstream repo (non-ec2)
+- name: Enable appstream repo for RHEL 8 (non-ec2)
   command: yum-config-manager --enable rhel-8-for-x86_64-appstream-rpms
   when:
     - ansible_distribution == 'RedHat'
     - ansible_distribution_major_version|int == 8
     - instance_loc != 'ec2'
-
-- name: Enable optional repos
-  command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-REGION-rhel-server-optional
-  when: ansible_distribution == 'RedHat'
 
 - name: Install packages
   package:

--- a/roles/windows-workstation/tasks/myrtille.yml
+++ b/roles/windows-workstation/tasks/myrtille.yml
@@ -47,12 +47,22 @@
     path: C:\Temp\Myrtille_2.5.5_x86_x64_Setup.exe
   register: myrtille
 
+- name: Download Myrtille to specified path only if modified (<2.9)
+  win_get_url:
+    url: https://github.com/cedrozor/myrtille/releases/download/v2.5.5/Myrtille_2.5.5_x86_x64_Setup.exe
+    dest: C:\Temp\Myrtille_2.5.5_x86_x64_Setup.exe
+  when:
+    - ansible_version.full is version('2.9', '<')
+    - not myrtille.stat.exists
+
 - name: Download Myrtille to specified path only if modified
   win_get_url:
     url: https://github.com/cedrozor/myrtille/releases/download/v2.5.5/Myrtille_2.5.5_x86_x64_Setup.exe
     dest: C:\Temp\Myrtille_2.5.5_x86_x64_Setup.exe
     follow_redirects: all
-  when: not myrtille.stat.exists
+  when:
+    - ansible_version.full is version('2.9', '>=')
+    - not myrtille.stat.exists
 
 - name: Extract the binary
   win_command: Myrtille_2.5.5_x86_x64_Setup.exe -o 'C:\Temp' -y

--- a/roles/windows-workstation/tasks/myrtille.yml
+++ b/roles/windows-workstation/tasks/myrtille.yml
@@ -51,11 +51,11 @@
   win_get_url:
     url: https://github.com/cedrozor/myrtille/releases/download/v2.5.5/Myrtille_2.5.5_x86_x64_Setup.exe
     dest: C:\Temp\Myrtille_2.5.5_x86_x64_Setup.exe
+    follow_redirects: all
   when: not myrtille.stat.exists
 
-
 - name: Extract the binary
-  win_command: Myrtille_2.5.5_x86_x64_Setup.exe -o "C:\Temp" -y
+  win_command: Myrtille_2.5.5_x86_x64_Setup.exe -o 'C:\Temp' -y
   args:
     chdir: C:\Temp\
     creates: C:\Temp\setup.exe

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -97,7 +97,7 @@ ec2_region: "us-east-1"
 
 # Internal lookup dict for image names and types
 ec2_image_names:
-  rhel7: "RHEL-7.6_HVM_GA*x86_64*"
+  rhel7: "RHEL-7.7_HVM_GA*x86_64*"
   rhel8: "RHEL-8.0.0_HVM_GA*x86_64*"
   centos7: "CentOS Linux 7 x86_64 HVM EBS ENA 1901_01*"
   win2016_core: "Windows_Server-2016-English-Core-Base*"
@@ -107,7 +107,7 @@ ec2_image_names:
 
 # Instance Sizes
 ec2_tower_instance_type: "t2.medium"    # Medium = 2 vCPU / 4GB
-ec2_tower_instance_ami_type: rhel7 # See the ec2_image_names variable for lookup
+ec2_tower_instance_ami_type: rhel8 # See the ec2_image_names variable for lookup
 ec2_gitlab_instance_type: "t2.medium"   # Might be able to use small...
 ec2_gitlab_instance_ami_type: rhel7 # See the ec2_image_names variable for lookup
 ec2_docs_instance_type: "t2.medium"
@@ -119,7 +119,6 @@ ec2_windows_workstation_instance_type: "t3.medium"   # t2.small was slowwwwww...
 ec2_windows_workstation_instance_ami_type: win2019_full # See the ec2_image_names variable for lookup
 ec2_windows_instance_type: "t3.small"   # Small = 1 vCPU / 2GB
 ec2_windows_instance_ami_type: win2019_core # See the ec2_image_names variable for lookup
-
 
 # letsencrypt config
 certbot_admin_email: register@{{ public_dns_zone | default ('') }}


### PR DESCRIPTION
- add support for ansible 2.9
- add support for running Tower on RHEL 8 on ec2